### PR TITLE
Redux/staged changes compatibility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,4 +5,7 @@
     "node": true,
     "es6": true
   },
+  "rules": {
+    "react/no-unused-prop-types": [2, {skipShapeProps: true}]
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.8.0
+
+* Fixing lint, adding skip shape props.
+
+
 ## 1.7.0
 
 * Fixing shortcut button class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.7.0
+
+* Fixing shortcut button class.
+* Fixing styles.
+
 ## 1.6.0
 
 * Adding position proptype.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-monthrange-picker",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "ReactJS Month range picker",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-monthrange-picker",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "ReactJS Month range picker",
   "main": "index.js",
   "scripts": {

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -9,6 +9,7 @@ require('moment-range');
 class App extends React.Component {
   constructor(props) {
     super(props);
+    this.redraw = props.redraw || false;
     this.handleClickFn = this.handleClick.bind(this);
     this.onSelectFn = this.onSelect.bind(this);
     this.onApplyFn = this.onApply.bind(this);
@@ -17,6 +18,28 @@ class App extends React.Component {
     const { selectedDateRange, restrictionRange, display } = props;
     this.state = { selectedDateRange, restrictionRange, display };
     this.selectedDateRange = selectedDateRange.clone();
+  }
+  componentWillReceiveProps(props) {
+    this.selectedDateRange = props.selectedDateRange.clone();
+    const sameDates = this.props.selectedDateRange.isSame(props.selectedDateRange);
+
+    // update state only if props are different, OR if forced
+    if(this.redraw || !sameDates) {
+      console.log('setting state to redraw', this.selectedDateRange.end.toString());
+      this.state.selectedDateRange = this.selectedDateRange.clone();
+      this.setState(this.state);
+    } else {
+      console.log('blocking redraw');
+    }
+  }
+  componentWillReceiveProps(props) {
+    this.selectedDateRange = props.selectedDateRange.clone();
+    const sameDates = this.props.selectedDateRange.isSame(props.selectedDateRange);
+    // update state only if props are different, OR if forced
+    if(this.redraw || !sameDates) {
+      this.state.selectedDateRange = this.selectedDateRange.clone();
+      this.setState(this.state);
+    }
   }
   componentDidMount() {
     if (this.props.onRender) {
@@ -47,6 +70,11 @@ class App extends React.Component {
     if (this.props.onCancel) {
       this.props.onCancel();
     }
+    this.setState(this.state);
+  }
+  syncData() {
+    // force a redraw by setting state
+    this.state.selectedDateRange = this.selectedDateRange.clone();
     this.setState(this.state);
   }
   handleClick(e) {


### PR DESCRIPTION
Prevents re-rendering of the component if you fire a Redux dispatch that doesn't change the selected range (which would otherwise reset the selected Range), but want to keep the changes you've made. E.g., if you want to stage your changes to allow a user to cancel/accept. Confirms a diff in dates before re-applying state unless the "redraw" prop is specified.